### PR TITLE
Add debug support and unit tests

### DIFF
--- a/test_chase_parser.py
+++ b/test_chase_parser.py
@@ -3,6 +3,9 @@
 Test script to debug Chase PDF parsing
 """
 
+import pytest
+pytest.skip("Debug script not intended as a test", allow_module_level=True)
+
 from pdf_processor import PDFProcessor
 import tempfile
 import os

--- a/test_pdf_processor_debug.py
+++ b/test_pdf_processor_debug.py
@@ -1,0 +1,28 @@
+import sys
+import types
+import pytest
+
+# Provide dummy modules so pdf_processor can be imported without real dependencies
+sys.modules.setdefault('pdfplumber', types.ModuleType('pdfplumber'))
+sys.modules.setdefault('PyPDF2', types.ModuleType('PyPDF2'))
+
+from pdf_processor import PDFProcessor
+
+
+def test_process_pdf_debug(monkeypatch):
+    sample_text = "Bank of America\n01/01/2024 Coffee Shop $5.00 $1000.00"
+
+    def mock_extract(self, file_path):
+        return sample_text
+
+    monkeypatch.setattr(PDFProcessor, "_extract_text_from_pdf", mock_extract)
+
+    processor = PDFProcessor()
+    result = processor.process_pdf("dummy.pdf", "dummy.pdf", debug=True)
+
+    assert result["success"] is True
+    assert "steps" in result
+    steps = result["steps"]
+    assert any(step.startswith("bank_detected:") for step in steps)
+    assert any(step.startswith("transactions_parsed:") for step in steps)
+    assert any(step.startswith("transactions_validated:") for step in steps)


### PR DESCRIPTION
## Summary
- enhance `PDFProcessor.process_pdf` to return detailed steps when `debug=True`
- skip old debug script during test collection
- add new pytest covering the debug flow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68479a92bc488325a501ad0eb0d7a430