### PR TITLE
Add debug mode

### DIFF
--- a/app.py
+++ b/app.py
@@ -58,6 +58,8 @@ def main():
         - Account
         - Transaction Type
         """)
+
+        debug_mode = st.checkbox("🐞 Debug Mode", value=False)
     
     # Main content area
     col1, col2 = st.columns([2, 1])
@@ -87,7 +89,7 @@ def main():
                 
                 # Process button
                 if st.button("🔄 Process Statements", type="primary", use_container_width=True):
-                    process_files(uploaded_files)
+                    process_files(uploaded_files, debug=debug_mode)
                     
             else:
                 st.error("❌ File validation failed:")
@@ -102,7 +104,7 @@ def main():
         else:
             st.info("Upload PDF files and click 'Process Statements' to begin.")
 
-def process_files(uploaded_files: List[Any]):
+def process_files(uploaded_files: List[Any], debug: bool = False):
     """Process uploaded PDF files and extract transaction data."""
     
     # Initialize progress tracking
@@ -135,7 +137,7 @@ def process_files(uploaded_files: List[Any]):
                     tmp_file_path = tmp_file.name
                 
                 # Process PDF
-                result = pdf_processor.process_pdf(tmp_file_path, uploaded_file.name)
+                result = pdf_processor.process_pdf(tmp_file_path, uploaded_file.name, debug=debug)
                 
                 if result['success']:
                     transactions = result['transactions']
@@ -143,12 +145,17 @@ def process_files(uploaded_files: List[Any]):
                     processing_summary['successful_files'] += 1
                     processing_summary['total_transactions'] += len(transactions)
                     processing_summary['banks_detected'].add(result['bank_detected'])
-                    
+
                     st.success(f"✅ {uploaded_file.name}: {len(transactions)} transactions extracted")
                 else:
                     processing_summary['failed_files'] += 1
                     processing_summary['errors'].append(f"{uploaded_file.name}: {result['error']}")
                     st.error(f"❌ {uploaded_file.name}: {result['error']}")
+
+                if debug and result.get('steps'):
+                    with st.expander(f"Debug Steps for {uploaded_file.name}"):
+                        for step in result['steps']:
+                            st.write(step)
                 
                 # Cleanup temporary file
                 os.unlink(tmp_file_path)

--- a/pdf_processor.py
+++ b/pdf_processor.py
@@ -16,15 +16,16 @@ class PDFProcessor:
         self.logger = logging.getLogger(__name__)
     
     def process_pdf(self, file_path: str, filename: str, debug: bool = False) -> Dict[str, Any]:
-        """
-        Process a PDF file and extract transaction data.
-        
+        """Process a PDF file and extract transaction data.
+
         Args:
-            file_path: Path to the PDF file
-            filename: Original filename for identification
-            
+            file_path: Path to the PDF file.
+            filename: Original filename for identification.
+            debug: When ``True``, a ``steps`` list describing each processing
+                stage is returned for debugging purposes.
+
         Returns:
-            Dictionary containing success status, transactions, and metadata
+            Dictionary containing success status, transactions, and metadata.
         """
         steps: List[str] = []
 


### PR DESCRIPTION
## Summary
- add Debug Mode checkbox in the sidebar
- enable pdf processing debug flow
- show per-file debug steps in an expander

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pdfplumber')*

------
https://chatgpt.com/codex/tasks/task_e_68479a87cdb48325a00d7f44a39a2223