### PR TITLE
Add logging setup and debug controls

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,12 +5,19 @@ import zipfile
 from typing import List, Dict, Any
 import tempfile
 import os
+import argparse
+import logging
 
 from pdf_processor import PDFProcessor
 from excel_generator import ExcelGenerator
-from utils import validate_pdf_files, format_currency
+from utils import validate_pdf_files, format_currency, setup_logging
 
-def main():
+def main(debug: bool = False):
+    setup_logging()
+    logger = logging.getLogger()
+    if debug:
+        logger.setLevel(logging.DEBUG)
+
     st.set_page_config(
         page_title="Bank Statement Processor",
         page_icon="🏦",
@@ -26,8 +33,9 @@ def main():
     if 'processing_complete' not in st.session_state:
         st.session_state.processing_complete = False
     
-    # Sidebar with instructions
+    # Sidebar with instructions and debug toggle
     with st.sidebar:
+        debug_enabled = st.checkbox("Enable debug logging", value=debug, key="debug_logging")
         st.header("📋 Instructions")
         st.markdown("""
         **Supported Banks:**
@@ -58,7 +66,13 @@ def main():
         - Account
         - Transaction Type
         """)
-    
+
+    # Adjust logging level based on checkbox
+    if debug_enabled:
+        logger.setLevel(logging.DEBUG)
+    else:
+        logger.setLevel(logging.INFO)
+
     # Main content area
     col1, col2 = st.columns([2, 1])
     
@@ -271,4 +285,7 @@ def display_results():
         st.rerun()
 
 if __name__ == "__main__":
-    main()
+    parser = argparse.ArgumentParser(description="Bank Statement Processor")
+    parser.add_argument("--debug", action="store_true", help="Enable debug logging")
+    args, _ = parser.parse_known_args()
+    main(debug=args.debug)


### PR DESCRIPTION
## Summary
- set up logging via `setup_logging()` when main starts
- add debug checkbox in sidebar
- support `--debug` CLI flag

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pdfplumber')*

------
https://chatgpt.com/codex/tasks/task_e_68479a8043d08325a393e9948d14500e