### PR TITLE
Add Banco Galicia parser

### DIFF
--- a/bank_parsers.py
+++ b/bank_parsers.py
@@ -37,7 +37,8 @@ class BaseBankParser:
             r'N[úu]mero de cuenta[:\s]+([A-Z0-9\s\-]+)',
             r'Account number[:\s]+([A-Z0-9\s\-]+)',
             r'IBAN[:\s]+([A-Z0-9\s]+)',
-            r'Cuenta[:\s]+([0-9\s\-]+)'
+            r'Cuenta[:\s]+([0-9\s\-]+)',
+            r'N°\s*([0-9\-\s]+)'
         ]
         
         for pattern in account_patterns:
@@ -207,9 +208,60 @@ class BBVAParser(SpanishBankParser):
 
 class CaixaBankParser(SpanishBankParser):
     """Parser for CaixaBank statements."""
-    
+
     def _get_bank_name(self) -> str:
         return "CaixaBank"
+
+class GaliciaParser(SpanishBankParser):
+    """Parser for Banco Galicia statements."""
+
+    def _get_bank_name(self) -> str:
+        return "Banco Galicia"
+
+    def parse_transactions(self, text_content: str, filename: str) -> List[Dict[str, Any]]:
+        transactions: List[Dict[str, Any]] = []
+        account_info = self._extract_account_info(text_content)
+
+        pattern = (
+            r'^(\d{2}/\d{2}/\d{2})\s+(.+?)\s+'  # date and description
+            r'([+-]?\d{1,3}(?:\.\d{3})*,\d{2})\s+'  # amount
+            r'([+-]?\d{1,3}(?:\.\d{3})*,\d{2})'      # balance
+        )
+
+        for line in text_content.split('\n'):
+            line = line.strip()
+            match = re.match(pattern, line)
+            if match:
+                try:
+                    date_str = match.group(1)
+                    description = clean_text(match.group(2))
+                    amount_str = match.group(3)
+                    balance_str = match.group(4)
+
+                    parsed_date = parse_date(date_str)
+                    if not parsed_date:
+                        continue
+
+                    amount = parse_amount(amount_str)
+                    balance = parse_amount(balance_str)
+
+                    transactions.append({
+                        'date': parsed_date,
+                        'description': description,
+                        'amount': amount,
+                        'balance': balance,
+                        'account': account_info['account_number'],
+                        'bank': self._get_bank_name(),
+                        'currency': account_info['currency'],
+                        'transaction_type': 'Credit' if amount > 0 else 'Debit'
+                    })
+                except (ValueError, IndexError) as e:
+                    self.logger.debug(f"Failed to parse line: {line}, error: {e}")
+
+        if not transactions:
+            transactions = super().parse_transactions(text_content, filename)
+
+        return transactions
 
 class GenericEnglishParser(BaseBankParser):
     """Parser for generic English bank statements."""
@@ -380,6 +432,7 @@ class BankParserFactory:
             'santander': SantanderParser(),
             'bbva': BBVAParser(),
             'caixabank': CaixaBankParser(),
+            'galicia': GaliciaParser(),
             'bankia': SpanishBankParser(),
             'sabadell': SpanishBankParser(),
             'unicaja': SpanishBankParser(),

--- a/pdf_processor.py
+++ b/pdf_processor.py
@@ -187,6 +187,7 @@ class PDFProcessor:
             'santander': 'santander',
             'bbva': 'bbva',
             'caixabank': 'caixabank',
+            'galicia': 'galicia',
             'bankia': 'bankia',
             'sabadell': 'sabadell',
             'unicaja': 'unicaja',

--- a/test_galicia_parser.py
+++ b/test_galicia_parser.py
@@ -1,0 +1,20 @@
+import pytest
+from bank_parsers import GaliciaParser
+from pdf_processor import PDFProcessor
+
+sample_text = "\n".join([
+    "05/05/25 DEB. AUTOM. DE SERV. -48.829,05 123.267,71",
+    "05/05/25 TRANSFERENCIA DE CUENTA 100.000,00 223.267,71",
+])
+
+def test_detect_bank_galicia():
+    processor = PDFProcessor()
+    assert processor._detect_bank("Banco de Galicia y Buenos Aires S.A.U.") == 'galicia'
+
+def test_galicia_parser():
+    parser = GaliciaParser()
+    txs = parser.parse_transactions(sample_text, "test.pdf")
+    assert len(txs) == 2
+    assert txs[0]['date'] == '2025-05-05'
+    assert txs[0]['amount'] == -48829.05
+    assert txs[1]['amount'] == 100000.00


### PR DESCRIPTION
## Summary
- support Banco Galicia statements
- update bank detection for Galicia
- test Galicia parser and detection

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847c3db61e88325ab9da6582b788cdb