### PR TITLE
Add ARS currency detection and tests

### DIFF
--- a/bank_parsers.py
+++ b/bank_parsers.py
@@ -52,6 +52,8 @@ class BaseBankParser:
             account_info['currency'] = 'USD'
         elif any(currency in text_content.upper() for currency in ['GBP', '£', 'POUND']):
             account_info['currency'] = 'GBP'
+        elif any(currency in text_content.upper() for currency in ['ARS', 'AR$', 'PESO']):
+            account_info['currency'] = 'ARS'
         
         return account_info
 

--- a/test_galicia_parser.py
+++ b/test_galicia_parser.py
@@ -3,6 +3,7 @@ from bank_parsers import GaliciaParser
 from pdf_processor import PDFProcessor
 
 sample_text = "\n".join([
+    "Cuenta en PESO",
     "05/05/25 DEB. AUTOM. DE SERV. -48.829,05 123.267,71",
     "05/05/25 TRANSFERENCIA DE CUENTA 100.000,00 223.267,71",
 ])
@@ -18,3 +19,4 @@ def test_galicia_parser():
     assert txs[0]['date'] == '2025-05-05'
     assert txs[0]['amount'] == -48829.05
     assert txs[1]['amount'] == 100000.00
+    assert all(t['currency'] == 'ARS' for t in txs)

--- a/utils.py
+++ b/utils.py
@@ -148,6 +148,8 @@ def format_currency(amount: float, currency: str = 'EUR') -> str:
         return f"${amount:,.2f}"
     elif currency == 'GBP':
         return f"£{amount:,.2f}"
+    elif currency == 'ARS':
+        return f"AR${amount:,.2f}"
     else:
         return f"{amount:,.2f} {currency}"
 


### PR DESCRIPTION
## Summary
- detect ARS (Argentine Peso) in `_extract_account_info`
- support ARS formatting in `format_currency`
- test for default ARS currency in Galicia parser

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848ad71f99083258faf147bd81194f4