### PR TITLE
Add Argentinian bank parser base

### DIFF
--- a/parsers/__init__.py
+++ b/parsers/__init__.py
@@ -5,9 +5,10 @@ from .spain.base import SpanishBankParser
 from .spain.santander import SantanderParser
 from .spain.bbva import BBVAParser
 from .spain.caixabank import CaixaBankParser
+from .argentina.base import ArgentinianBankParser
 from .argentina.galicia import GaliciaParser
 
 __all__ = [
     'BaseBankParser', 'SpanishBankParser', 'SantanderParser', 'BBVAParser',
-    'CaixaBankParser', 'GaliciaParser', 'GenericEnglishParser', 'BankParserFactory'
+    'CaixaBankParser', 'ArgentinianBankParser', 'GaliciaParser', 'GenericEnglishParser', 'BankParserFactory'
 ]

--- a/parsers/argentina/__init__.py
+++ b/parsers/argentina/__init__.py
@@ -1,3 +1,3 @@
+from .base import ArgentinianBankParser
 from .galicia import GaliciaParser
-
-__all__ = ['GaliciaParser']
+__all__ = ['ArgentinianBankParser', 'GaliciaParser']

--- a/parsers/argentina/base.py
+++ b/parsers/argentina/base.py
@@ -1,0 +1,24 @@
+"""Clases base para bancos argentinos."""
+
+from typing import Dict
+
+from ..spain.base import SpanishBankParser
+
+
+class ArgentinianBankParser(SpanishBankParser):
+    """Parser genérico para extractos de bancos argentinos."""
+
+    bank_id = "generic_argentinian"
+    aliases = ["argentina", "generic_argentinian"]
+
+    def _extract_account_info(self, text_content: str) -> Dict[str, str]:
+        """Extiende la detección de cuenta poniendo ARS como moneda por defecto."""
+
+        info = super()._extract_account_info(text_content)
+        if info.get("currency") == "EUR":
+            info["currency"] = "ARS"
+        return info
+
+    def _get_bank_name(self) -> str:
+        return "Argentinian Bank"
+

--- a/parsers/argentina/galicia.py
+++ b/parsers/argentina/galicia.py
@@ -1,10 +1,10 @@
 from typing import List, Dict, Any
 import re
 
-from ..spain.base import SpanishBankParser
+from .base import ArgentinianBankParser
 from utils import clean_text, parse_amount, parse_date
 
-class GaliciaParser(SpanishBankParser):
+class GaliciaParser(ArgentinianBankParser):
     """Parser para Banco Galicia de Argentina."""
 
     bank_id = 'galicia'

--- a/test_argentinian_parser.py
+++ b/test_argentinian_parser.py
@@ -1,0 +1,11 @@
+import pytest
+from parsers.argentina.base import ArgentinianBankParser
+
+sample_text = "05/05/2025 Compra en tienda -1000,00 5000,00"
+
+def test_argentinian_default_currency_and_date():
+    parser = ArgentinianBankParser()
+    txs = parser.parse_transactions(sample_text, "test.pdf")
+    assert len(txs) == 1
+    assert txs[0]['date'] == '2025-05-05'
+    assert txs[0]['currency'] == 'ARS'


### PR DESCRIPTION
## Summary
- implement `ArgentinianBankParser` with ARS default
- make `GaliciaParser` inherit from the new base
- export new parser classes
- add tests for ARS default currency parsing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848c2690b0083259ca4edb30edf87b1