### PR TITLE
Dinamizar registro de parsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,12 @@ streamlit run app.py -- --debug
 - Cambiar la casilla mientras la aplicación está en ejecución ajustará el nivel de registro inmediatamente y la configuración se mantiene entre recargas.
 
 El flag de la CLI solo controla el estado inicial; la casilla de la barra lateral es la fuente de verdad después del arranque.
+
+## Agregar nuevos parsers
+
+Para soportar un banco adicional basta con crear un nuevo módulo dentro del
+directorio `parsers/` (o cualquiera de sus subpaquetes) que contenga una clase
+heredada de `BaseBankParser`. Define el atributo `bank_id` y, opcionalmente,
+`aliases` con otros identificadores reconocibles. Al importar el paquete
+`parsers` las clases se registran automáticamente y `BankParserFactory` podrá
+instanciarlas sin pasos extra.

--- a/parsers/__init__.py
+++ b/parsers/__init__.py
@@ -1,14 +1,47 @@
-from .base import BaseBankParser
-from .generic import GenericEnglishParser
-from .factory import BankParserFactory
-from .spain.base import SpanishBankParser
-from .spain.santander import SantanderParser
-from .spain.bbva import BBVAParser
-from .spain.caixabank import CaixaBankParser
-from .argentina.base import ArgentinianBankParser
-from .argentina.galicia import GaliciaParser
+"""Inicialización del paquete de parsers.
 
-__all__ = [
-    'BaseBankParser', 'SpanishBankParser', 'SantanderParser', 'BBVAParser',
-    'CaixaBankParser', 'ArgentinianBankParser', 'GaliciaParser', 'GenericEnglishParser', 'BankParserFactory'
-]
+Este módulo descubre automáticamente todos los parsers disponibles y los
+registra en :data:`PARSER_REGISTRY`. Cualquier subclase de
+``BaseBankParser`` dentro del paquete ``parsers`` queda disponible al
+importar ``parsers``.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Type
+
+import importlib
+import inspect
+import pkgutil
+
+from .base import BaseBankParser
+
+PARSER_REGISTRY: Dict[str, Type[BaseBankParser]] = {}
+
+__all__ = ["BaseBankParser"]
+
+
+def _discover_parsers() -> None:
+    """Importa submódulos y registra subclases de ``BaseBankParser``."""
+
+    package = importlib.import_module(__name__)
+    for _, module_name, _ in pkgutil.walk_packages(
+        package.__path__, package.__name__ + "."
+    ):
+        module = importlib.import_module(module_name)
+        for name, obj in inspect.getmembers(module, inspect.isclass):
+            if issubclass(obj, BaseBankParser) and obj is not BaseBankParser:
+                globals()[name] = obj
+                if name not in __all__:
+                    __all__.append(name)
+                keys = [obj.bank_id] + list(getattr(obj, "aliases", []))
+                for key in filter(None, keys):
+                    PARSER_REGISTRY.setdefault(key, obj)
+
+
+_discover_parsers()
+
+from .factory import BankParserFactory
+
+__all__.append("BankParserFactory")
+

--- a/parsers/factory.py
+++ b/parsers/factory.py
@@ -1,34 +1,26 @@
-import pkgutil
-import importlib
-import inspect
-from typing import Optional
+from typing import Optional, Dict, Type
 
+from . import PARSER_REGISTRY
 from .base import BaseBankParser
 
 class BankParserFactory:
-    """Fábrica que registra dinámicamente todos los parsers."""
+    """Fábrica que instancia parsers usando :data:`PARSER_REGISTRY`."""
 
     def __init__(self) -> None:
-        self.parsers: dict[str, BaseBankParser] = {}
-        self._discover_parsers()
-
-    def _discover_parsers(self) -> None:
-        package = importlib.import_module(__name__.split('.')[0])
-        for _, module_name, _ in pkgutil.walk_packages(package.__path__, package.__name__ + '.'):
-            module = importlib.import_module(module_name)
-            for _, obj in inspect.getmembers(module, inspect.isclass):
-                if issubclass(obj, BaseBankParser) and obj is not BaseBankParser:
-                    parser_instance = obj()
-                    keys = [obj.bank_id] + list(getattr(obj, 'aliases', []))
-                    for key in filter(None, keys):
-                        if key not in self.parsers:
-                            self.parsers[key] = parser_instance
+        self._instances: Dict[Type[BaseBankParser], BaseBankParser] = {}
 
     def get_parser(self, bank_identifier: str) -> Optional[BaseBankParser]:
-        parser = self.parsers.get(bank_identifier)
-        if not parser and bank_identifier != 'unknown':
-            if any(k in bank_identifier.lower() for k in ['spanish', 'spain', 'españa']):
-                parser = self.parsers.get('generic_spanish')
+        cls = PARSER_REGISTRY.get(bank_identifier)
+        if not cls and bank_identifier != "unknown":
+            if any(k in bank_identifier.lower() for k in ["spanish", "spain", "españa"]):
+                cls = PARSER_REGISTRY.get("generic_spanish")
             else:
-                parser = self.parsers.get('generic_english')
-        return parser
+                cls = PARSER_REGISTRY.get("generic_english")
+
+        if cls is None:
+            return None
+
+        if cls not in self._instances:
+            self._instances[cls] = cls()
+
+        return self._instances[cls]


### PR DESCRIPTION
## Summary
- registrar los parsers al importar `parsers` y exponerlos en `PARSER_REGISTRY`
- hacer que `BankParserFactory` instancie los parsers desde ese registro
- documentar la forma de añadir nuevos parsers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848c3b2bcdc8325b10ddf0303d6c21f