### PR TITLE
Remove explicit host and port from Streamlit config

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,7 +1,2 @@
 [server]
 headless = true
-address = "0.0.0.0"
-port = 5000
-
-[theme]
-base = "light"


### PR DESCRIPTION
## Summary
- simplify `.streamlit/config.toml`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6849868e0b60832595460f72c8dcc5ce