### PR TITLE
Fix default currency for Argentinian statements

### DIFF
--- a/parsers/argentina/base.py
+++ b/parsers/argentina/base.py
@@ -12,11 +12,30 @@ class ArgentinianBankParser(SpanishBankParser):
     aliases = ["argentina", "generic_argentinian"]
 
     def _extract_account_info(self, text_content: str) -> Dict[str, str]:
-        """Extiende la detección de cuenta poniendo ARS como moneda por defecto."""
+        """Extiende la detección de cuenta poniendo ARS como moneda por defecto.
+
+        La clase base ``BaseBankParser`` asume Dólares (USD) cuando detecta el
+        símbolo ``$`` en el texto. Sin embargo, en Argentina el signo ``$`` se
+        utiliza para indicar Pesos, por lo que dicha heurística genera una
+        detección incorrecta. Aquí normalizamos la moneda de la siguiente
+        manera:
+
+        - Si se encuentran indicadores explícitos de dólares (``USD``, ``U$`` o
+          ``U$S``) se establece ``USD``.
+        - En cualquier otro caso se utiliza ``ARS`` como valor por defecto.
+        """
 
         info = super()._extract_account_info(text_content)
-        if info.get("currency") == "EUR":
+
+        text_upper = text_content.upper()
+        usd_indicators = ["USD", "U$S", "U$"]
+
+        if any(indicator in text_upper for indicator in usd_indicators):
+            info["currency"] = "USD"
+        else:
+            # Predeterminar a pesos argentinos
             info["currency"] = "ARS"
+
         return info
 
     def _get_bank_name(self) -> str:

--- a/test_argentinian_parser.py
+++ b/test_argentinian_parser.py
@@ -2,10 +2,26 @@ import pytest
 from parsers.argentina.base import ArgentinianBankParser
 
 sample_text = "05/05/2025 Compra en tienda -1000,00 5000,00"
+sample_text_usd = "Cuenta en USD\n05/05/2025 Compra en tienda -1000,00 5000,00"
+sample_text_peso = "Caja de Ahorro en Pesos $172.096,76\n05/05/2025 Compra en tienda -1000,00 5000,00"
 
 def test_argentinian_default_currency_and_date():
     parser = ArgentinianBankParser()
     txs = parser.parse_transactions(sample_text, "test.pdf")
     assert len(txs) == 1
     assert txs[0]['date'] == '2025-05-05'
+    assert txs[0]['currency'] == 'ARS'
+
+
+def test_argentinian_usd_detection():
+    parser = ArgentinianBankParser()
+    txs = parser.parse_transactions(sample_text_usd, "test.pdf")
+    assert len(txs) == 1
+    assert txs[0]['currency'] == 'USD'
+
+
+def test_argentinian_peso_detection_with_dollar_sign():
+    parser = ArgentinianBankParser()
+    txs = parser.parse_transactions(sample_text_peso, "test.pdf")
+    assert len(txs) == 1
     assert txs[0]['currency'] == 'ARS'


### PR DESCRIPTION
## Summary
- fix currency detection in Argentinian base parser
- add tests for USD and ARS detection

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849889a54e083259a2516d9253c3e40