### PR TITLE
Support multiline descriptions in Galicia parser

### DIFF
--- a/parsers/argentina/galicia.py
+++ b/parsers/argentina/galicia.py
@@ -1,4 +1,4 @@
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Optional
 import re
 
 from .base import ArgentinianBankParser
@@ -17,32 +17,108 @@ class GaliciaParser(ArgentinianBankParser):
         transactions: List[Dict[str, Any]] = []
         account_info = self._extract_account_info(text_content)
 
-        pattern = (
+        start_tx_re = re.compile(
             r'^(\d{2}/\d{2}/\d{2})\s+(.+?)\s+'
             r'([+-]?\d{1,3}(?:\.\d{3})*,\d{2})\s+'
             r'([+-]?\d{1,3}(?:\.\d{3})*,\d{2})'
         )
 
-        for line in text_content.split('\n'):
-            line = line.strip()
-            match = re.match(pattern, line)
+        current_match: Optional[re.Match] = None
+        desc_lines: List[str] = []
+
+        for raw_line in text_content.split('\n'):
+            line = raw_line.strip()
+            if not line:
+                continue
+
+            match = start_tx_re.match(line)
             if match:
-                try:
-                    date_str = match.group(1)
-                    description = clean_text(match.group(2))
-                    amount_str = match.group(3)
-                    balance_str = match.group(4)
+                if current_match:
+                    try:
+                        date_str = current_match.group(1)
+                        base_desc = clean_text(current_match.group(2))
+                        amount_str = current_match.group(3)
+                        balance_str = current_match.group(4)
+                        parsed_date = parse_date(date_str)
+                        if parsed_date:
+                            amount = parse_amount(amount_str)
+                            balance = parse_amount(balance_str)
+                            full_desc = base_desc
+                            if desc_lines:
+                                full_desc += ' ' + ' '.join(desc_lines)
+                            transactions.append({
+                                'date': parsed_date,
+                                'description': full_desc,
+                                'amount': amount,
+                                'balance': balance,
+                                'account': account_info['account_number'],
+                                'bank': self._get_bank_name(),
+                                'currency': account_info['currency'],
+                                'transaction_type': 'Credit' if amount > 0 else 'Debit'
+                            })
+                    except (ValueError, IndexError) as e:
+                        self.logger.debug(f"Failed to parse line: {line}, error: {e}")
 
-                    parsed_date = parse_date(date_str)
-                    if not parsed_date:
-                        continue
+                current_match = match
+                desc_lines = []
+                continue
 
+            if current_match:
+                if re.match(r'^(Resumen de Caja|Página|Fecha\s+Descripción|Movimientos|Datos de la cuenta)', line, re.IGNORECASE):
+                    continue
+                if re.match(r'^\d{2}/\d{2}/\d{2}', line):
+                    # Nuevo inicio que no coincidió completamente, procesar existente
+                    try:
+                        date_str = current_match.group(1)
+                        base_desc = clean_text(current_match.group(2))
+                        amount_str = current_match.group(3)
+                        balance_str = current_match.group(4)
+                        parsed_date = parse_date(date_str)
+                        if parsed_date:
+                            amount = parse_amount(amount_str)
+                            balance = parse_amount(balance_str)
+                            full_desc = base_desc
+                            if desc_lines:
+                                full_desc += ' ' + ' '.join(desc_lines)
+                            transactions.append({
+                                'date': parsed_date,
+                                'description': full_desc,
+                                'amount': amount,
+                                'balance': balance,
+                                'account': account_info['account_number'],
+                                'bank': self._get_bank_name(),
+                                'currency': account_info['currency'],
+                                'transaction_type': 'Credit' if amount > 0 else 'Debit'
+                            })
+                    except (ValueError, IndexError) as e:
+                        self.logger.debug(f"Failed to parse line: {line}, error: {e}")
+
+                    current_match = None
+                    desc_lines = []
+                    # Re-evaluar la línea actual por si es un nuevo comienzo válido
+                    match = start_tx_re.match(line)
+                    if match:
+                        current_match = match
+                    continue
+
+                desc_lines.append(clean_text(line))
+
+        if current_match:
+            try:
+                date_str = current_match.group(1)
+                base_desc = clean_text(current_match.group(2))
+                amount_str = current_match.group(3)
+                balance_str = current_match.group(4)
+                parsed_date = parse_date(date_str)
+                if parsed_date:
                     amount = parse_amount(amount_str)
                     balance = parse_amount(balance_str)
-
+                    full_desc = base_desc
+                    if desc_lines:
+                        full_desc += ' ' + ' '.join(desc_lines)
                     transactions.append({
                         'date': parsed_date,
-                        'description': description,
+                        'description': full_desc,
                         'amount': amount,
                         'balance': balance,
                         'account': account_info['account_number'],
@@ -50,8 +126,8 @@ class GaliciaParser(ArgentinianBankParser):
                         'currency': account_info['currency'],
                         'transaction_type': 'Credit' if amount > 0 else 'Debit'
                     })
-                except (ValueError, IndexError) as e:
-                    self.logger.debug(f"Failed to parse line: {line}, error: {e}")
+            except (ValueError, IndexError) as e:
+                self.logger.debug(f"Failed to parse line: {line}, error: {e}")
 
         if not transactions:
             transactions = super().parse_transactions(text_content, filename)

--- a/test_galicia_parser.py
+++ b/test_galicia_parser.py
@@ -8,6 +8,27 @@ sample_text = "\n".join([
     "05/05/25 TRANSFERENCIA DE CUENTA 100.000,00 223.267,71",
 ])
 
+sample_text_multiline = "\n".join([
+    "05/05/25 DEB. AUTOM. DE SERV. -48.829,05 123.267,71",
+    "ANSES RES 193 23",
+    "NORMAL",
+    "0001092143_015",
+    "23318277559",
+    "05/05/25 TRANSFERENCIA DE CUENTA 100.000,00 223.267,71",
+    "PROPIA",
+    "ROJAS/LEM SANTIAGO L",
+    "23318277559",
+    "01703311400000492384",
+    "3310004923847",
+    "4517650653303578",
+    "VARIOS",
+    "05/05/25 DEB. AUTOM. DE SERV. -166.046,59 57.221,12",
+    "OMINT SA",
+    "CUOTAS 1",
+    "FAC 5006276065",
+    "19729417",
+])
+
 def test_detect_bank_galicia():
     processor = PDFProcessor()
     assert processor._detect_bank("Banco de Galicia y Buenos Aires S.A.U.") == 'galicia'
@@ -20,3 +41,10 @@ def test_galicia_parser():
     assert txs[0]['amount'] == -48829.05
     assert txs[1]['amount'] == 100000.00
     assert all(t['currency'] == 'ARS' for t in txs)
+
+
+def test_galicia_multiline_description():
+    parser = GaliciaParser()
+    txs = parser.parse_transactions(sample_text_multiline, "test.pdf")
+    assert len(txs) == 3
+    assert "ANSES RES 193 23 NORMAL 0001092143_015 23318277559" in txs[0]['description']


### PR DESCRIPTION
## Summary
- enhance Galicia parser to accumulate multiline descriptions
- add test for multiline descriptions using snippet from TestGalicia.pdf

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68499bac24e483259cbef6f18c33eb26