### PR TITLE
Handle Galicia ID by country and show full bank names

### DIFF
--- a/app.py
+++ b/app.py
@@ -236,7 +236,7 @@ def process_files(uploaded_files: List[Any], debug: bool = False):
                     all_transactions.extend(transactions)
                     processing_summary['successful_files'] += 1
                     processing_summary['total_transactions'] += len(transactions)
-                    processing_summary['banks_detected'].add(result['bank_detected'])
+                    processing_summary['banks_detected'].add(result.get('bank_name', result['bank_detected']))
 
                     st.success(tr("transactions_extracted", name=uploaded_file.name, count=len(transactions)))
                 else:

--- a/parsers/argentina/galicia.py
+++ b/parsers/argentina/galicia.py
@@ -7,11 +7,11 @@ from utils import clean_text, parse_amount, parse_date
 class GaliciaParser(ArgentinianBankParser):
     """Parser para Banco Galicia de Argentina."""
 
-    bank_id = 'galicia'
+    bank_id = 'galicia_ar'
     aliases = ['galicia']
 
     def _get_bank_name(self) -> str:
-        return "Banco Galicia"
+        return "Banco Galicia (Arg.)"
 
     def parse_transactions(self, text_content: str, filename: str) -> List[Dict[str, Any]]:
         transactions: List[Dict[str, Any]] = []

--- a/parsers/generic.py
+++ b/parsers/generic.py
@@ -13,6 +13,9 @@ class GenericEnglishParser(BaseBankParser):
         'hsbc', 'barclays', 'deutsche_bank'
     ]
 
+    def _get_bank_name(self) -> str:
+        return "English Bank"
+
     def parse_transactions(self, text_content: str, filename: str) -> List[Dict[str, Any]]:
         transactions: List[Dict[str, Any]] = []
         account_info = self._extract_account_info(text_content)
@@ -55,7 +58,7 @@ class GenericEnglishParser(BaseBankParser):
                             'amount': amount,
                             'balance': balance if balance is not None else '',
                             'account': account_info['account_number'],
-                            'bank': "English Bank",
+                            'bank': self._get_bank_name(),
                             'currency': account_info['currency'],
                             'transaction_type': 'Credit' if amount > 0 else 'Debit'
                         })

--- a/pdf_processor.py
+++ b/pdf_processor.py
@@ -55,6 +55,7 @@ class PDFProcessor:
                     'error': 'Could not extract text from PDF. File may be image-based or corrupted.',
                     'transactions': [],
                     'bank_detected': 'Unknown',
+                    'bank_name': '',
                 }
                 if debug and debug_log is not None:
                     debug_log.append("Failed to extract text")
@@ -76,6 +77,7 @@ class PDFProcessor:
                     'error': f'No parser available for detected bank: {bank_detected}',
                     'transactions': [],
                     'bank_detected': bank_detected,
+                    'bank_name': '',
                 }
                 if debug and debug_log is not None:
                     debug_log.append(f"No parser found for bank: {bank_detected}")
@@ -101,6 +103,7 @@ class PDFProcessor:
                 'success': True,
                 'transactions': valid_transactions,
                 'bank_detected': bank_detected,
+                'bank_name': parser._get_bank_name(),
                 'total_transactions': len(valid_transactions),
             }
             if debug and debug_log is not None:
@@ -114,6 +117,7 @@ class PDFProcessor:
                 'error': f'Processing error: {e}',
                 'transactions': [],
                 'bank_detected': 'Unknown',
+                'bank_name': '',
             }
             if debug and debug_log is not None:
                 debug_log.append(f"Exception occurred: {e}")
@@ -207,7 +211,7 @@ class PDFProcessor:
             'santander': 'santander',
             'bbva': 'bbva',
             'caixabank': 'caixabank',
-            'galicia': 'galicia',
+            'galicia': 'galicia_ar',
             'bankia': 'bankia',
             'sabadell': 'sabadell',
             'unicaja': 'unicaja',

--- a/test_galicia_parser.py
+++ b/test_galicia_parser.py
@@ -31,7 +31,7 @@ sample_text_multiline = "\n".join([
 
 def test_detect_bank_galicia():
     processor = PDFProcessor()
-    assert processor._detect_bank("Banco de Galicia y Buenos Aires S.A.U.") == 'galicia'
+    assert processor._detect_bank("Banco de Galicia y Buenos Aires S.A.U.") == 'galicia_ar'
 
 def test_galicia_parser():
     parser = GaliciaParser()


### PR DESCRIPTION
## Summary
- add `_get_bank_name` to `GenericEnglishParser`
- change Galicia parser identifier to `galicia_ar` and return full name
- detect Galicia Argentina using the new identifier
- expose bank name from `PDFProcessor.process_pdf`
- show full bank names in the Streamlit UI
- adjust tests for new `galicia_ar` id

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849a55d6dac8325a91c3512a170a4f9