### PR TITLE
Actualiza interfaz y README con bancos soportados

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,27 @@ streamlit run app.py -- --debug
 
 El flag de la CLI solo controla el estado inicial; la casilla de la barra lateral es la fuente de verdad después del arranque.
 
+## Bancos Soportados
+
+La aplicación incluye parsers específicos para los siguientes bancos (además de parsers genéricos para formatos en español e inglés):
+
+- Banco Santander
+- BBVA
+- CaixaBank
+- Banco Galicia (Argentina)
+- Bankia
+- Sabadell
+- Unicaja
+- Kutxabank
+- Ibercaja
+- Chase
+- Bank of America
+- Wells Fargo
+- Citibank
+- HSBC
+- Barclays
+- Deutsche Bank
+
 ## Agregar nuevos parsers
 
 Para soportar un banco adicional basta con crear un nuevo módulo dentro del

--- a/app.py
+++ b/app.py
@@ -10,7 +10,7 @@ import logging
 
 from pdf_processor import PDFProcessor
 from excel_generator import ExcelGenerator
-from utils import validate_pdf_files, format_currency, setup_logging
+from utils import validate_pdf_files, format_currency, setup_logging, get_supported_banks
 
 # Internacionalización sencilla
 LANG = "es"
@@ -30,9 +30,10 @@ TRANSLATIONS = {
     "debug_mode": {"en": "\U0001f41e Debug Mode", "es": "\U0001f41e Modo Depuraci\u00F3n"},
     "instructions_header": {"en": "\U0001f4cb Instructions", "es": "\U0001f4cb Instrucciones"},
     "instructions_text": {
-        "en": """\n        **Supported Banks:**\n        - Most common banks (PDF text format)\n        - Spanish banks (Santander, BBVA, CaixaBank, etc.)\n        - International banks with standard formats\n\n        **File Requirements:**\n        - PDF format only\n        - Text-based PDFs (not scanned images)\n        - Maximum 10 files per upload\n        - Maximum 50MB per file\n\n        **Output:**\n        - Structured Excel file\n        - Standardized transaction format\n        - Summary statistics\n        """,
-        "es": """\n        **Bancos Soportados:**\n        - La mayor\u00EDa de bancos comunes (formato PDF de texto)\n        - Bancos espa\u00F1oles (Santander, BBVA, CaixaBank, etc.)\n        - Bancos internacionales con formatos est\u00E1ndar\n\n        **Requisitos de Archivo:**\n        - Solo formato PDF\n        - PDFs basados en texto (no im\u00E1genes escaneadas)\n        - M\u00E1ximo 10 archivos por carga\n        - M\u00E1ximo 50MB por archivo\n\n        **Salida:**\n        - Archivo Excel estructurado\n        - Formato de transacciones estandarizado\n        - Estad\u00EDsticas resumidas\n        """,
+        "en": """\n        **File Requirements:**\n        - PDF format only\n        - Text-based PDFs (not scanned images)\n        - Maximum 10 files per upload\n        - Maximum 50MB per file\n\n        **Output:**\n        - Structured Excel file\n        - Standardized transaction format\n        - Summary statistics\n        """,
+        "es": """\n        **Requisitos de Archivo:**\n        - Solo formato PDF\n        - PDFs basados en texto (no im\u00E1genes escaneadas)\n        - M\u00E1ximo 10 archivos por carga\n        - M\u00E1ximo 50MB por archivo\n\n        **Salida:**\n        - Archivo Excel estructurado\n        - Formato de transacciones estandarizado\n        - Estad\u00EDsticas resumidas\n        """,
     },
+    "supported_banks_header": {"en": "\U0001f3e6 Supported Banks", "es": "\U0001f3e6 Bancos Soportados"},
     "sample_header": {"en": "\U0001f4ca Sample Output Structure", "es": "\U0001f4ca Ejemplo de Estructura de Salida"},
     "sample_text": {
         "en": """\n        **Columns in Excel:**\n        - Date\n        - Description\n        - Amount\n        - Balance\n        - Bank\n        - Account\n        - Transaction Type\n        """,
@@ -143,6 +144,10 @@ def main(debug: bool = False, lang: str = LANG):
         debug_enabled = st.checkbox(tr("debug_mode"), value=debug, key="debug_logging")
         st.header(tr("instructions_header"))
         st.markdown(tr("instructions_text"))
+
+        st.header(tr("supported_banks_header"))
+        for bank in get_supported_banks():
+            st.markdown(f"- {bank}")
 
         st.header(tr("sample_header"))
         st.markdown(tr("sample_text"))

--- a/utils.py
+++ b/utils.py
@@ -282,5 +282,54 @@ def extract_account_number(text: str) -> Optional[str]:
         match = re.search(pattern, text, re.IGNORECASE)
         if match:
             return match.group(1).strip().replace(' ', '').replace('-', '')
-    
+
     return None
+
+
+def get_supported_banks() -> List[str]:
+    """Return a sorted list of human friendly bank names currently supported."""
+
+    from parsers import PARSER_REGISTRY
+
+    display_map = {
+        "bbva": "BBVA",
+        "hsbc": "HSBC",
+        "bank_of_america": "Bank of America",
+        "wells_fargo": "Wells Fargo",
+        "deutsche_bank": "Deutsche Bank",
+        "citibank": "Citibank",
+        "barclays": "Barclays",
+        "bankia": "Bankia",
+        "sabadell": "Sabadell",
+        "kutxabank": "Kutxabank",
+        "ibercaja": "Ibercaja",
+        "unicaja": "Unicaja",
+        "caixabank": "CaixaBank",
+        "chase": "Chase",
+    }
+
+    generic_aliases = {
+        "generic_spanish",
+        "generic_english",
+        "generic_argentinian",
+        "argentina",
+    }
+
+    specialized = {
+        "SantanderParser",
+        "BBVAParser",
+        "CaixaBankParser",
+        "GaliciaParser",
+    }
+
+    banks = set()
+    for alias, cls in PARSER_REGISTRY.items():
+        if alias in generic_aliases:
+            continue
+
+        if cls.__name__ in specialized:
+            banks.add(cls()._get_bank_name())
+        else:
+            banks.add(display_map.get(alias, alias.replace("_", " ").title()))
+
+    return sorted(banks)


### PR DESCRIPTION
## Summary
- lista dinámica de bancos en la barra lateral
- añade función `get_supported_banks` en `utils`
- documenta bancos soportados en README

## Testing
- `pip install -r requirements.txt`
- `pytest -q test`

------
https://chatgpt.com/codex/tasks/task_e_684cab6447988325b6d796743bfc5a78