### PR TITLE
Improve Roela bank detection with CBU pattern

### DIFF
--- a/pdf_processor.py
+++ b/pdf_processor.py
@@ -207,7 +207,9 @@ class PDFProcessor:
         """
         text_lower = text_content.lower()
 
-        if re.search(r"CBU\s*:?\s*247\d{19}", text_content):
+        # Banco Roela detection - look for C.B.U. or CBU followed by the prefix
+        # 247 and 19 additional digits (total 22 digits)
+        if re.search(r"C\.?B\.?U\.?\s*:?\s*247\d{19}", text_content, re.IGNORECASE):
             return "roela_ar"
 
         keywords = {

--- a/test_detect_bank.py
+++ b/test_detect_bank.py
@@ -12,3 +12,9 @@ def test_detect_bank_roela():
     processor = PDFProcessor()
     sample_text = "Cuenta corriente CBU: 2470001810000002253782"
     assert processor._detect_bank(sample_text) == 'roela_ar'
+
+
+def test_detect_bank_roela_with_dots():
+    processor = PDFProcessor()
+    sample_text = "C.B.U. 2470001810000002253782"
+    assert processor._detect_bank(sample_text) == 'roela_ar'


### PR DESCRIPTION
## Summary
- improve `_detect_bank` to recognize `C.B.U.` with prefix `247` followed by 19 digits
- add regression test for the dotted CBU pattern

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cb268a3248325bdfac9ee74ad6b74