### PR TITLE
Ensure Roela parser reads PDF columns left-to-right

### DIFF
--- a/parsers/argentina/roela_ar.py
+++ b/parsers/argentina/roela_ar.py
@@ -26,9 +26,18 @@ class RoelaParser(ArgentinianBankParser):
                 with pdfplumber.open(filename) as pdf:
                     extracted = ""
                     for page in pdf.pages:
-                        page_text = page.extract_text(x_tolerance=1, y_tolerance=3)
-                        if page_text:
-                            extracted += page_text + "\n"
+                        # Dividir la página en dos mitades para preservar
+                        # correctamente el orden de lectura de izquierda a
+                        # derecha.
+                        left = page.within_bbox((0, 0, page.width / 2, page.height))
+                        right = page.within_bbox((page.width / 2, 0, page.width, page.height))
+
+                        for section in (left, right):
+                            if section is None:
+                                continue
+                            page_text = section.extract_text(x_tolerance=1, y_tolerance=3)
+                            if page_text:
+                                extracted += page_text + "\n"
             except Exception:
                 # Si falla la lectura del PDF, usar el texto proporcionado
                 extracted = text_content

--- a/test_roela_parser.py
+++ b/test_roela_parser.py
@@ -9,3 +9,22 @@ def test_roela_parser():
     txs = parser.parse_transactions(sample_text, "test.pdf")
     assert len(txs) >= 5
     assert all(t["currency"] == "ARS" for t in txs)
+
+
+def test_roela_parser_pdf_order():
+    parser = RoelaParser()
+    with open("attached_assets/TestBancoRoelaArg.txt", "r") as f:
+        sample_text = f.read()
+
+    txs_text = parser.parse_transactions(sample_text, "dummy.pdf")
+    txs_pdf = parser.parse_transactions("", "attached_assets/BancoRoela.Argentina.Test.pdf")
+
+    pdf_desc = [t["description"] for t in txs_pdf]
+    target_desc = [t["description"] for t in txs_text[:5]]
+
+    pos = 0
+    for desc in target_desc:
+        while pos < len(pdf_desc) and pdf_desc[pos] != desc:
+            pos += 1
+        assert pos < len(pdf_desc)
+        pos += 1


### PR DESCRIPTION
## Summary
- parse Banco Roela statements left then right using `within_bbox`
- verify order of parsed transactions from PDF matches text example

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ce6603f888325b8d40f98de73ce3d